### PR TITLE
docs: clarify what the action does and add a flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # helm-charts-updater
 
-A tool that will update helm charts in a given repository
+A GitHub Action that bumps a Helm chart in your charts repository when you release your app
 
 [![CI](https://img.shields.io/github/actions/workflow/status/shini4i/helm-charts-updater/qa.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/shini4i/helm-charts-updater/actions/workflows/qa.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/shini4i/helm-charts-updater/main?style=flat-square&logo=codecov&logoColor=white&label=coverage)](https://codecov.io/gh/shini4i/helm-charts-updater)
@@ -13,19 +13,57 @@ A tool that will update helm charts in a given repository
 
 </div>
 
-## Project Description
+## What It Does
+
+You keep your Helm charts in one repository and your application code in another. When the
+application is released, its chart has to be updated — a new `appVersion` and a new chart
+`version`. This action does that update for you, from the application's release pipeline.
+
+Given a chart name and a new app version, it:
+
+1. Clones the charts repository.
+2. Sets `appVersion` to the new version and bumps the chart `version` patch number.
+3. Commits and pushes the change back.
+
+Optionally it also writes an [Artifact Hub](https://artifacthub.io) changelog annotation,
+regenerates the chart's README with [helm-docs](https://github.com/norwoodj/helm-docs), and
+refreshes a table of all charts in the charts repository's README.
+
+Nothing is committed if the chart already has the requested `appVersion`.
+
+```mermaid
+flowchart LR
+    subgraph app["App repository"]
+        release["Release v1.2.3"]
+    end
+
+    subgraph updater["helm-charts-updater"]
+        direction TB
+        bump["version: 0.1.0 → 0.1.1<br/>appVersion: 1.2.2 → 1.2.3"]
+        extras["Optional:<br/>Artifact Hub annotation<br/>helm-docs<br/>charts table"]
+        bump --> extras
+    end
+
+    subgraph charts["Charts repository"]
+        chart["charts/my-chart/Chart.yaml"]
+    end
+
+    release -- "triggers" --> bump
+    chart -- "clone" --> bump
+    extras -- "commit & push" --> chart
+```
+
+### Requirements
+
+- The chart must use `appVersion` as its image tag, so bumping `appVersion` is enough to deploy
+  the new release.
+- The token passed as `github_token` must be allowed to push to the charts repository.
 
 > [!WARNING]
-> Currently, only patch version bump is supported for chart version.
+> Only a patch bump of the chart `version` is supported.
 
-The use case is relatively niche. The idea is that there are a lot of helm charts in a single git
-repository, and it is required to bump both chart version and appVersion from a pipeline in a different repository.
-
-So it is required that the selected helm chart uses appVersion as an image tag.
-
-Additionally, it can generate helm readme and generate table of the existing charts in the main README.md file.
-
-It might be a good tandem for the [chart-releaser-action](https://github.com/helm/chart-releaser-action).
+Pairs well with [chart-releaser-action](https://github.com/helm/chart-releaser-action), which
+packages and publishes the charts once this action has bumped them.
 
 ## Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Helm Charts Updater"
 author: "Vadim Gedz"
-description: "A tool that will update helm charts in a given repository"
+description: "Bump a chart's appVersion and version in a separate Helm charts repository when your app is released"
 branding:
   icon: anchor
   color: gray-dark

--- a/helm_charts_updater/__init__.py
+++ b/helm_charts_updater/__init__.py
@@ -1,7 +1,8 @@
-"""Helm Charts Updater - A tool to update helm charts in a given repository.
+"""Helm Charts Updater - bump a chart in a separate Helm charts repository.
 
-This package provides functionality to automatically update Helm chart
-versions and push changes to a GitHub repository.
+Clones a GitHub repository holding Helm charts, sets the target chart's
+appVersion and bumps its chart version, then commits and pushes the change.
+Optionally regenerates chart docs and the charts table in the repository README.
 """
 
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "helm-charts-updater"
 version = "0.4.3"
-description = "A tool that will update helm charts in a given repository"
+description = "Bump a chart's appVersion and version in a separate Helm charts repository when your app is released"
 authors = [{ name = "Vadim Gedz", email = "vadims@linux-tech.io" }]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Lead with the two-repository setup and the concrete update steps instead of the "niche use case" framing, move the appVersion-as-image-tag and push-permission constraints into a Requirements section, and add a mermaid flowchart of the app repo -> updater -> charts repo flow.

Align the one-line description across README, action.yml, pyproject.toml and the package docstring.